### PR TITLE
Fix duplicate entries in activity logs

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -666,7 +666,7 @@ var Sprint;
     attr: function(name, value) {
       var isFunc = typeof value == "function"
       if (typeof value == "string" || typeof value == "number" || isFunc) {
-        return this.each(function(i) { xAprVB7Psm
+        return this.each(function(i) {
           if (this.nodeType > 1) return
           this.setAttribute(
             name, isFunc ? value.call(this, i, this.getAttribute(name)) : value


### PR DESCRIPTION
Resolved a bug where activity logs recorded duplicate entries for the same event.